### PR TITLE
Enable use of converters on xs:simpleType

### DIFF
--- a/jrecordbind-test/src/test/java/it/assist/jrecordbind/test/TypesafeEnumTest.java
+++ b/jrecordbind-test/src/test/java/it/assist/jrecordbind/test/TypesafeEnumTest.java
@@ -1,0 +1,68 @@
+/*
+ * JRecordBind, fixed-length file (un)marshaller
+ * Copyright 2009, Assist s.r.l., and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package it.assist.jrecordbind.test;
+
+import static org.junit.Assert.*;
+import org.junit.Test;
+
+import java.io.InputStreamReader;
+import java.util.Iterator;
+
+import it.assist.jrecordbind.Unmarshaller;
+import it.assist_si.schemas.jrb.typesafeenumtest.EnumOne;
+import it.assist_si.schemas.jrb.typesafeenumtest.EnumRecord;
+import it.assist_si.schemas.jrb.typesafeenumtest.EnumTwo;
+
+public class TypesafeEnumTest {
+
+  private final Unmarshaller<EnumRecord> unmarshaller;
+
+  public TypesafeEnumTest() throws Exception {
+    unmarshaller = new Unmarshaller<EnumRecord>(new InputStreamReader(TypesafeEnumTest.class
+        .getResourceAsStream("/typesafeEnumTest.def.xsd")));
+  }
+
+  @Test
+  public void unmarshall() throws Exception {
+    Iterator<EnumRecord> iter = unmarshaller.unmarshall(new InputStreamReader(
+        EnumWithRestrictionsRecordUnmarshallTest.class.getResourceAsStream("typesafeEnumTest.txt")));
+
+    assertTrue(iter.hasNext());
+    EnumRecord record = iter.next();
+    assertEquals(EnumOne.ONE, record.getEnumOne());
+    assertEquals(EnumTwo.ONE, record.getEnumTwo());
+    record = iter.next();
+    assertEquals(EnumOne.TWO, record.getEnumOne());
+    assertEquals(EnumTwo.TWO, record.getEnumTwo());
+    record = iter.next();
+    assertEquals(EnumOne.THREE, record.getEnumOne());
+    assertEquals(EnumTwo.THREE, record.getEnumTwo());
+    record = iter.next();
+    assertEquals(EnumOne.NINE, record.getEnumOne());
+    assertEquals(EnumTwo.FIVE, record.getEnumTwo());
+
+    assertFalse(iter.hasNext());
+    assertEquals("", unmarshaller.getCurrentJunk());
+  }
+
+}

--- a/jrecordbind-test/src/test/java/it/assist/jrecordbind/test/TypesafeEnumTestConverters.java
+++ b/jrecordbind-test/src/test/java/it/assist/jrecordbind/test/TypesafeEnumTestConverters.java
@@ -1,0 +1,56 @@
+/*
+ * JRecordBind, fixed-length file (un)marshaller
+ * Copyright 2009, Assist s.r.l., and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package it.assist.jrecordbind.test;
+
+import it.assist.jrecordbind.Converter;
+import it.assist_si.schemas.jrb.typesafeenumtest.EnumOne;
+import it.assist_si.schemas.jrb.typesafeenumtest.EnumTwo;
+
+public class TypesafeEnumTestConverters {
+
+  private TypesafeEnumTestConverters() {
+
+  }
+
+  public static class EnumOneConverter implements Converter {
+
+    public Object convert(String value) {
+      return EnumOne.fromValue(value.trim());
+    }
+
+    public String toString(Object value) {
+      return ((EnumOne) value).value();
+    }
+
+  }
+
+  public static class EnumTwoConverter implements Converter {
+
+    public Object convert(String value) {
+      return EnumTwo.fromValue(value.trim());
+    }
+
+    public String toString(Object value) {
+      return ((EnumTwo) value).value();
+    }
+  }
+}

--- a/jrecordbind-test/src/test/resources/it/assist/jrecordbind/test/typesafeEnumTest.txt
+++ b/jrecordbind-test/src/test/resources/it/assist/jrecordbind/test/typesafeEnumTest.txt
@@ -1,0 +1,4 @@
+1         ONE       
+2         TWO       
+3         THREE     
+9         FIVE      

--- a/jrecordbind-test/src/test/resources/typesafeEnumTest.def.xsd
+++ b/jrecordbind-test/src/test/resources/typesafeEnumTest.def.xsd
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema
+  xmlns="http://schemas.assist-si.it/jrb/typesafeEnumTest"
+  targetNamespace="http://schemas.assist-si.it/jrb/typesafeEnumTest"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:jrb="http://jrecordbind.dev.java.net/2/xsd"
+  xmlns:jxb="http://java.sun.com/xml/ns/jaxb"
+  jxb:version="2.0"
+  elementFormDefault="qualified" attributeFormDefault="unqualified">
+
+  <xs:element name="main" type="EnumRecord" jrb:length="20" />
+
+  <xs:complexType name="EnumRecord">
+    <xs:sequence>
+      <xs:element name="enumOne" type="EnumOne" jrb:length="10" />
+      <xs:element name="enumTwo" type="EnumTwo" jrb:length="10" />
+    </xs:sequence>
+  </xs:complexType>
+
+
+  <xs:simpleType name="EnumOne" jrb:converter="it.assist.jrecordbind.test.TypesafeEnumTestConverters$EnumOneConverter">
+    <xs:annotation>
+      <xs:appinfo>
+        <jxb:typesafeEnumClass />
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="1">
+        <xs:annotation>
+          <xs:appinfo>
+            <jxb:typesafeEnumMember name="ONE"/>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="2">
+        <xs:annotation>
+          <xs:appinfo>
+            <jxb:typesafeEnumMember name="TWO"/>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="3">
+        <xs:annotation>
+          <xs:appinfo>
+            <jxb:typesafeEnumMember name="THREE"/>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="4">
+        <xs:annotation>
+          <xs:appinfo>
+            <jxb:typesafeEnumMember name="FOUR"/>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="9">
+        <xs:annotation>
+          <xs:appinfo>
+            <jxb:typesafeEnumMember name="NINE"/>
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:enumeration>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="EnumTwo" jrb:converter="it.assist.jrecordbind.test.TypesafeEnumTestConverters$EnumTwoConverter">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="ONE" />
+      <xs:enumeration value="TWO" />
+      <xs:enumeration value="THREE" />
+      <xs:enumeration value="FOUR" />
+      <xs:enumeration value="FIVE" />
+    </xs:restriction>
+  </xs:simpleType>
+</xs:schema>

--- a/jrecordbind/src/main/java/it/assist/jrecordbind/EvaluatorBuilder.java
+++ b/jrecordbind/src/main/java/it/assist/jrecordbind/EvaluatorBuilder.java
@@ -83,6 +83,11 @@ class EvaluatorBuilder {
       if (!facets.isEmpty()) {
         target.setType(packageName + "." + NameConverter.standard.toClassName(source.getName()));
       }
+      
+      String converter = source.getForeignAttribute(Constants.JRECORDBIND_XSD, "converter");
+      if (converter != null) {
+        target.setConverter(converter);
+      }
     }
   }
 


### PR DESCRIPTION
In order to enable use of converter classes to convert to/from enums produced by `xjc`, parse `xs:simpleType` elements for the `jrb:converter` attribute.

This is not the cleanest solution, as it requires users to write a converter class for each enum they intend to use, but given that converters must be stateless there doesn't seem to be a better solution (the converter can't rely on reflection, for example, because it doesn't know the correct enum class at runtime).
