### PR TITLE
Project cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .idea
 *.iml
+/jrecordbind/target/
+/jrecordbind-test/target/

--- a/jrecordbind-test/pom.xml
+++ b/jrecordbind-test/pom.xml
@@ -8,11 +8,13 @@
   <name>JRecordBind test module</name>
   <description>Transform fixed-length and variable-length text files into beans and back</description>
   <url>http://jrecordbind.org</url>
+  
   <parent>
     <groupId>it.assist.jrecordbind</groupId>
     <artifactId>jrecordbind-parent</artifactId>
     <version>2.3.9-SNAPSHOT</version>
   </parent>
+  
   <dependencies>
     <dependency>
       <groupId>junit</groupId>
@@ -26,6 +28,7 @@
       <version>2.3.9-SNAPSHOT</version>
     </dependency>
   </dependencies>
+  
   <build>
     <plugins>
       <plugin>

--- a/jrecordbind/pom.xml
+++ b/jrecordbind/pom.xml
@@ -8,16 +8,19 @@
   <name>JRecordBind</name>
   <description>Transform fixed-length and variable-length text files into beans and back</description>
   <url>http://jrecordbind.org</url>
+  
   <parent>
     <groupId>it.assist.jrecordbind</groupId>
     <artifactId>jrecordbind-parent</artifactId>
     <version>2.3.9-SNAPSHOT</version>
   </parent>
+  
   <scm>
     <url>http://java.net/projects/jrecordbind/sources/svn/show</url>
     <connection>scm:svn:https://svn.java.net/svn/jrecordbind~svn/trunk/jrecordbind</connection>
     <developerConnection>scm:svn:https://svn.java.net/svn/jrecordbind~svn/trunk/jrecordbind</developerConnection>
   </scm>
+  
   <dependencies>
     <dependency>
       <groupId>relaxngDatatype</groupId>
@@ -38,7 +41,8 @@
       <scope>compile</scope>
     </dependency>
   </dependencies>
-  <build>
+  
+  <build>    
     <plugins>
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
@@ -50,10 +54,10 @@
       </plugin>
     </plugins>
   </build>
+  
   <reporting>
     <plugins>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
           <linksource>true</linksource>

--- a/pom.xml
+++ b/pom.xml
@@ -10,10 +10,10 @@
   <parent>
     <groupId>net.java</groupId>
     <artifactId>jvnet-parent</artifactId>
-    <version>1</version>
+    <version>5</version>
   </parent>
   <issueManagement>
-    <system>JIRA</system>
+    <system>GitHub</system>
     <url>http://java.net/jira/browse/JRECORDBIND</url>
   </issueManagement>
   <scm>
@@ -62,9 +62,7 @@
       <build>
         <plugins>
           <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>1.1</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>
@@ -85,14 +83,45 @@
     <javadoc.url>http://download.oracle.com/javase/1.5.0/docs/api/</javadoc.url>
   </properties>
   <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <artifactId>maven-site-plugin</artifactId>
+          <version>2.3</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.1</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-eclipse-plugin</artifactId>
+          <version>2.8</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-assembly-plugin</artifactId>
+          <version>2.4.1</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-javadoc-plugin</artifactId>
+          <version>2.9.1</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-gpg-plugin</artifactId>
+          <version>1.5</version>
+        </plugin>
+        <plugin>
+          <groupId>org.jvnet.jaxb2.maven2</groupId>
+          <artifactId>maven-jaxb2-plugin</artifactId>
+          <version>0.9.0</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+
     <plugins>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-site-plugin</artifactId>
-        <version>2.3</version>
       </plugin>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <inherited>true</inherited>
         <configuration>
@@ -101,7 +130,6 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-eclipse-plugin</artifactId>
         <version>2.8</version>
         <configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -14,12 +14,12 @@
   </parent>
   <issueManagement>
     <system>GitHub</system>
-    <url>http://java.net/jira/browse/JRECORDBIND</url>
+    <url>https://github.com/ffissore/jrecordbind/issues</url>
   </issueManagement>
   <scm>
-    <connection>scm:svn:https://svn.java.net/svn/jrecordbind~svn/trunk</connection>
-    <developerConnection>scm:svn:https://svn.java.net/svn/jrecordbind~svn/trunk</developerConnection>
-    <url>http://java.net/projects/jrecordbind/sources/svn/show</url>
+    <connection>scm:git:https://github.com/ffissore/jrecordbind.git</connection>
+    <developerConnection>scm:git:git@github.com:ffissore/jrecordbind.git</developerConnection>
+    <url>https://github.com/ffissore/jrecordbind</url>
   </scm>
   <developers>
     <developer>


### PR DESCRIPTION
This PR fixes the `.gitignore` file to ignore the products of compilation, and performs minor cleanup on the POMs (mainly updating plugin versions and pointing links to GitHub).
