### PR TITLE
New Attribute - jrb:placeholder

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,12 @@ The custom attributes are:
     <td>if you are using jaxb bindings.xjb with the <b>&quot;globalBindings choiceContentProperty='true'&quot;</b> option active, you <b>need</b> to specify the name of the method jaxb has actually generated</td>
     <td>Yes, if you have set choiceContentProperty='true'. No, otherwise</td>
   </tr>
+  <tr class="b">
+    <td>jrb:placeholder</td>
+    <td>single elements</td>
+    <td>use this attribute to specify static values for marshalling instead of declaring them inside your beans.</td>
+    <td>No, JRecordBind will default to its standard behaviour</td>
+  </tr>
 </table>
 
 When you are ready with your definition, generate the beans:

--- a/jrecordbind-test/src/test/java/it/assist/jrecordbind/test/SimpleFixedRecordMarshallTest.java
+++ b/jrecordbind-test/src/test/java/it/assist/jrecordbind/test/SimpleFixedRecordMarshallTest.java
@@ -1,0 +1,62 @@
+/*
+ * JRecordBind, fixed-length file (un)marshaller
+ * Copyright 2009, Assist s.r.l., and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package it.assist.jrecordbind.test;
+
+import static org.junit.Assert.*;
+import it.assist.jrecordbind.Marshaller;
+import it.assist_si.schemas.jrb.simplefixed.SimpleFixedRecord;
+
+import java.io.InputStreamReader;
+import java.io.StringWriter;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class SimpleFixedRecordMarshallTest {
+
+  private Marshaller<SimpleFixedRecord> marshaller;
+  private SimpleFixedRecord record;
+  private StringWriter stringWriter;
+
+  
+  @Test
+  public void marshallOne() throws Exception {
+    marshaller.marshall(record, stringWriter);
+    assertEquals("NAME fixedValue\n", stringWriter.toString());
+
+    assertEquals(16, stringWriter.toString().length());
+  }
+
+
+  @Before
+  public void setUp() throws Exception {
+    record = new SimpleFixedRecord();
+    record.setDynamic("NAME");
+
+
+    marshaller = new Marshaller<SimpleFixedRecord>(new InputStreamReader(SimpleFixedRecordMarshallTest.class
+        .getResourceAsStream("/simpleFixed.def.xsd")));
+
+    stringWriter = new StringWriter();
+  }
+}

--- a/jrecordbind-test/src/test/resources/simpleFixed.def.xsd
+++ b/jrecordbind-test/src/test/resources/simpleFixed.def.xsd
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema targetNamespace="http://schemas.assist-si.it/jrb/simpleFixed" 
+           xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+           xmlns="http://schemas.assist-si.it/jrb/simpleFixed" 
+           xmlns:jrb="http://jrecordbind.dev.java.net/2/xsd" 
+           elementFormDefault="qualified" 
+           attributeFormDefault="unqualified">
+  <xs:complexType name="SimpleFixedRecord">
+    <xs:sequence>
+      <xs:element name="dynamic" type="xs:string" jrb:length="5" />
+      <xs:element name="fixed" type="xs:string" jrb:placeholder="fixedValue"  />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:element name="main" type="SimpleFixedRecord" jrb:length="15" />
+</xs:schema>

--- a/jrecordbind/src/main/java/it/assist/jrecordbind/EvaluatorBuilder.java
+++ b/jrecordbind/src/main/java/it/assist/jrecordbind/EvaluatorBuilder.java
@@ -129,6 +129,17 @@ class EvaluatorBuilder {
     }
 
   }
+  
+  static final class PlaceholderEval implements Evaluator<Property, XSElementDecl> {
+
+    public void eval(Property target, XSElementDecl source) {
+      String placeholder = source.getForeignAttribute(Constants.JRECORDBIND_XSD, "placeholder");
+      if (placeholder != null) {
+        target.setPlaceholder(placeholder);
+      }
+    }
+
+  }
 
   static final class LineSeparatorRecordEval implements Evaluator<RecordDefinition, XSElementDecl> {
 
@@ -229,6 +240,7 @@ class EvaluatorBuilder {
     propertiesEvals.add(new LengthPropertyEval());
     propertiesEvals.add(new ConverterEval());
     propertiesEvals.add(new PadderEval());
+    propertiesEvals.add(new PlaceholderEval());
 
     mainElementEvals = new LinkedList<Evaluator<RecordDefinition, XSElementDecl>>();
     mainElementEvals.add(new DelimiterEval());

--- a/jrecordbind/src/main/java/it/assist/jrecordbind/Marshaller.java
+++ b/jrecordbind/src/main/java/it/assist/jrecordbind/Marshaller.java
@@ -183,10 +183,14 @@ public class Marshaller<E> extends AbstractUnMarshaller {
       } else {
         currentPadder = padders.get(currentDefinition.getGlobalPadder());
       }
-      String value = currentPadder.pad(converters.get(property.getConverter()).toString(
-          propertyUtils.getProperty(record, property.getName())), property.getLength());
+      
+      // If there is a placeholder use that value instead of then one specified inside the bean.
+      Converter converter = converters.get(property.getConverter()); 
+      Object propertyValue = (property.getPlaceholder() != null) ? property.getPlaceholder(): propertyUtils.getProperty(record, property.getName());
+      String value = currentPadder.pad( converter.toString( propertyValue ), property.getLength() );
+
       sb.append(ensureCorrectLength(property.getLength(), value));
-      length += property.getLength();
+      length += (property.getPlaceholder() == null) ? property.getLength() : property.getPlaceholder().length();
       if (iter.hasNext()) {
         sb.append(currentDefinition.getPropertyDelimiter());
         length += currentDefinition.getPropertyDelimiter().length();

--- a/jrecordbind/src/main/java/it/assist/jrecordbind/RecordDefinition.java
+++ b/jrecordbind/src/main/java/it/assist/jrecordbind/RecordDefinition.java
@@ -52,6 +52,7 @@ class RecordDefinition {
     private int row;
     private String type;
     private final EnumPropertyHelper enumPropertyHelper;
+    private String placeholder;    
 
     /**
      * Creates a new Property
@@ -166,6 +167,14 @@ class RecordDefinition {
 
     public boolean isEnum() {
       return enumPropertyHelper.isEnum();
+    }
+    
+    public String getPlaceholder() {
+        return placeholder;
+    }
+
+    public void setPlaceholder(String placeholder) {
+        this.placeholder = placeholder;
     }
 
   }


### PR DESCRIPTION
Hi! I've just created a new attribute jrb:placeholder that is used only during marshaling of
beans. This new attribute will allow to specify static values directly inside the xsd definition. I've also developed a specific test case for the new attribute. 
## Usage Example
### XSD Schema Definition

``` xml
<?xml version="1.0" encoding="UTF-8"?>
[...]
  <xs:complexType name="T0001Record">
    <xs:sequence>
      [...]
      <xs:element name="token" type="xs:string" jrb:length="8" />
      <xs:element name="recordTypeID" type="xs:string" jrb:placeholder="T0001"  />
    </xs:sequence>
  </xs:complexType>
[...]
</xs:schema>
```
### Marshalling Code

``` java
//some bean taken somewhere
T0001Record record = new T0001Record();
record.setToken("0fae4bc8");

//setting up the marshaller
[...]

//marshalling
marshaller.marshall(record, writer);
System.out.println(writer.toString());
```
### Generated Output

``` txt
[...] 0fae4bc8 T0001
```
